### PR TITLE
Derek/20230524-bug-fix-syncing-clear-conversation

### DIFF
--- a/components/Chatbar/Chatbar.tsx
+++ b/components/Chatbar/Chatbar.tsx
@@ -175,6 +175,10 @@ export const Chatbar = () => {
     homeDispatch({ field: 'folders', value: updatedFolders });
     saveFolders(updatedFolders);
     updateConversationLastUpdatedAtTimeStamp();
+
+    homeDispatch({ field: 'forceSyncConversation', value: true });
+    homeDispatch({ field: 'replaceRemoteData', value: true });
+
     event('interaction', {
       category: 'Conversation',
       label: 'Clear conversations',

--- a/pages/api/home/home.state.tsx
+++ b/pages/api/home/home.state.tsx
@@ -4,7 +4,7 @@ import { FolderInterface } from '@/types/folder';
 import { OpenAIModel, OpenAIModelID } from '@/types/openai';
 import { PluginKey } from '@/types/plugin';
 import { Prompt } from '@/types/prompt';
-import { User, CreditUsage } from '@/types/user';
+import { CreditUsage, User } from '@/types/user';
 
 import { SupabaseClient } from '@supabase/supabase-js';
 
@@ -37,6 +37,7 @@ export interface HomeInitialState {
   conversationLastSyncAt: number | null;
   conversationLastUpdatedAt: number | null;
   forceSyncConversation: boolean;
+  replaceRemoteData: boolean;
   syncingConversation: boolean;
   syncSuccess: boolean | null; // null = not yet synced
 
@@ -89,6 +90,7 @@ export const initialState: HomeInitialState = {
   conversationLastSyncAt: null,
   conversationLastUpdatedAt: null,
   forceSyncConversation: true, // Sync on first load
+  replaceRemoteData: false,
   syncingConversation: false,
   syncSuccess: null,
 

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -98,6 +98,7 @@ const Home = ({
       isPaidUser,
       conversationLastSyncAt,
       forceSyncConversation,
+      replaceRemoteData,
     },
     dispatch,
   } = contextValue;
@@ -272,7 +273,7 @@ const Home = ({
   ) => {
     const updatedConversation = {
       ...conversation,
-      [data.key]: data.value
+      [data.key]: data.value,
     };
 
     const { single, all } = updateConversation(
@@ -323,6 +324,7 @@ const Home = ({
         const syncResult: LatestExportFormat | null = await syncData(
           supabase,
           user,
+          replaceRemoteData,
         );
 
         if (syncResult !== null) {
@@ -336,12 +338,10 @@ const Home = ({
 
           // skip if selected conversation is already in history
           const selectedConversationFromRemote = history.find(
-            (remoteConversation) => remoteConversation.id === selectedConversation?.id,
+            (remoteConversation) =>
+              remoteConversation.id === selectedConversation?.id,
           );
-          if (
-            selectedConversation &&
-            selectedConversationFromRemote
-          ) {
+          if (selectedConversation && selectedConversationFromRemote) {
             dispatch({
               field: 'selectedConversation',
               value: selectedConversationFromRemote,
@@ -357,6 +357,7 @@ const Home = ({
       if (forceSyncConversation) {
         dispatch({ field: 'forceSyncConversation', value: false });
       }
+      dispatch({ field: 'replaceRemoteData', value: false });
       dispatch({ field: 'syncSuccess', value: true });
       dispatch({ field: 'syncingConversation', value: false });
     };

--- a/utils/app/importExport.ts
+++ b/utils/app/importExport.ts
@@ -8,6 +8,7 @@ import {
 } from '@/types/export';
 
 import { cleanConversationHistory } from './clean';
+
 import dayjs from 'dayjs';
 
 export function isExportFormatV1(obj: any): obj is ExportFormatV1 {
@@ -75,20 +76,11 @@ export const getExportableData = (): LatestExportFormat => {
   const folders = localStorage.getItem('folders');
   const prompts = localStorage.getItem('prompts');
 
-  if (history) {
-    return {
-      version: 4,
-      history: JSON.parse(history),
-      folders: folders ? JSON.parse(folders) : [],
-      prompts: prompts ? JSON.parse(prompts) : [],
-    };
-  }
-
   return {
     version: 4,
-    history: [],
-    folders: [],
-    prompts: [],
+    history: history ? JSON.parse(history) : [],
+    folders: folders ? JSON.parse(folders) : [],
+    prompts: prompts ? JSON.parse(prompts) : [],
   };
 };
 

--- a/utils/app/sync.ts
+++ b/utils/app/sync.ts
@@ -102,7 +102,6 @@ const mergeTwoObjects = (
   let mergedObject: MergeableObject;
 
   if (localObject !== null && remoteObject !== null) {
-
     // If both conversations are not deleted, then we compare the lastUpdateAtUTC
     mergedObject =
       (remoteObject.lastUpdateAtUTC || 0) > (localObject.lastUpdateAtUTC || 0)
@@ -164,6 +163,7 @@ const mergeTwoMergeableCollections = (
 export const syncData = async (
   supabase: SupabaseClient,
   user: User,
+  replaceRemoteData: boolean = false,
 ): Promise<LatestExportFormat | null> => {
   let mergedHistory: Conversation[] = [];
   let mergedFolders: FolderInterface[] = [];
@@ -176,7 +176,7 @@ export const syncData = async (
   let remoteConversations: Conversation[] = [];
   let localConversations = cleanConversationHistory(localDataObject.history);
 
-  if (remoteDataObject) {
+  if (remoteDataObject && !replaceRemoteData) {
     remoteConversations = cleanConversationHistory(remoteDataObject.history);
   }
 
@@ -189,7 +189,7 @@ export const syncData = async (
   let remoteFolders: FolderInterface[] = [];
   let localFolders = localDataObject.folders;
 
-  if (remoteDataObject) {
+  if (remoteDataObject && !replaceRemoteData) {
     remoteFolders = remoteDataObject.folders;
   }
 
@@ -202,7 +202,7 @@ export const syncData = async (
   let remotePrompts: Prompt[] = [];
   let localPrompts = localDataObject.prompts;
 
-  if (remoteDataObject) {
+  if (remoteDataObject && !replaceRemoteData) {
     remotePrompts = remoteDataObject.prompts;
   }
 


### PR DESCRIPTION
Fix clear conversation not working with the syncing feature enabled

There are 3 doable implementation options:

1. Hard delete on both sides
- Pros:
  - Reduces data size during API calls.
  - Frees up local storage on the client side.
- Cons:
  - If a user logs in on an old computer, the previously deleted data will sync to the cloud again. (It is uncertain whether this is a Con.)

2. Soft delete on both sides
- Pros:
  - All records are preserved.
- Cons:
  - Increases data size during API calls.
  - The old conversations will eventually be replaced by the latest ones, remaining deleted.

3. Hard delete on the local side only
- Pros:
  - Deleted records are retained on the server and can be retrieved if a new feature is developed based on this.
  - Frees up local storage on the client side.
- Cons:
  - Increases data size during API calls.
  - When the user logs in from an old computer, the old data will be deleted.

The first option is more intuitive for users I would say, so I went with that approach. Please let me know if you have any other thoughts on this.