### PR TITLE
Long title text in prompt template covers the deletion confirmation buttons

### DIFF
--- a/components/Promptbar/components/Prompt.tsx
+++ b/components/Promptbar/components/Prompt.tsx
@@ -93,7 +93,11 @@ export const PromptComponent = ({ prompt }: Props) => {
       >
         <IconBulbFilled size={18} />
 
-        <div className="relative max-h-5 flex-1 overflow-hidden text-ellipsis whitespace-nowrap break-all pr-4 text-left text-[12.5px] leading-3">
+        <div
+          className={`${
+            isDeleting || isRenaming ? 'pr-12' : 'pr-4'
+          } relative max-h-5 flex-1 overflow-hidden text-ellipsis whitespace-nowrap break-all text-left text-[12.5px] leading-3`}
+        >
           {prompt.name}
         </div>
       </button>


### PR DESCRIPTION
Fix issue where delete buttons are covered when text gets too long.