### PR TITLE
Jack/20230614-auto-select-16k-context-window-model

### DIFF
--- a/components/Chat/components/TokenCounter.tsx
+++ b/components/Chat/components/TokenCounter.tsx
@@ -39,7 +39,8 @@ function TokenCounter({
       case 'gpt-4':
         return OpenAIModels[OpenAIModelID.GPT_4].tokenLimit;
       default:
-        return OpenAIModels[OpenAIModelID.GPT_3_5].tokenLimit;
+        // The Chat endpoint will automatically use the 16k content window model if the prompt is longer than 2048 tokens
+        return OpenAIModels[OpenAIModelID.GPT_3_5_16K].tokenLimit;
     }
   }, [currentMessage?.pluginId]);
 

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -1,6 +1,10 @@
+// This endpoint only allow GPT-3.5 and GPT-3.5 16K models
 import { DEFAULT_SYSTEM_PROMPT, DEFAULT_TEMPERATURE } from '@/utils/app/const';
 import { OpenAIError, OpenAIStream } from '@/utils/server';
-import { shortenMessagesBaseOnTokenLimit } from '@/utils/server/api';
+import {
+  getMessagesTokenCount,
+  shortenMessagesBaseOnTokenLimit,
+} from '@/utils/server/api';
 import { retrieveUserSessionAndLogUsages } from '@/utils/server/usagesTracking';
 
 import { ChatBody } from '@/types/chat';
@@ -17,8 +21,7 @@ const handler = async (req: Request): Promise<Response> => {
     const selectedOutputLanguage = req.headers.get('Output-Language')
       ? `{lang=${req.headers.get('Output-Language')}}`
       : '';
-    const { model, messages, prompt, temperature } =
-      (await req.json()) as ChatBody;
+    const { messages, prompt, temperature } = (await req.json()) as ChatBody;
 
     let promptToSend = prompt;
     if (!promptToSend) {
@@ -30,10 +33,17 @@ const handler = async (req: Request): Promise<Response> => {
       temperatureToUse = DEFAULT_TEMPERATURE;
     }
 
+    const defaultTokenLimit = OpenAIModels[OpenAIModelID.GPT_3_5].tokenLimit;
+    const extendedTokenLimit =
+      OpenAIModels[OpenAIModelID.GPT_3_5_16K].tokenLimit;
+
+    const useLargerContextWindowModel =
+      (await getMessagesTokenCount(messages)) > defaultTokenLimit;
+    
     const messagesToSend = await shortenMessagesBaseOnTokenLimit(
       prompt,
       messages,
-      model.tokenLimit,
+      extendedTokenLimit,
     );
 
     if (selectedOutputLanguage) {
@@ -45,7 +55,9 @@ const handler = async (req: Request): Promise<Response> => {
     }
 
     const stream = await OpenAIStream(
-      OpenAIModels[OpenAIModelID.GPT_3_5],
+      useLargerContextWindowModel
+        ? OpenAIModels[OpenAIModelID.GPT_3_5_16K]
+        : OpenAIModels[OpenAIModelID.GPT_3_5],
       promptToSend,
       temperatureToUse,
       messagesToSend,

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -8,8 +8,10 @@ export interface OpenAIModel {
 }
 
 export enum OpenAIModelID {
-  GPT_3_5 = 'gpt-3.5-turbo',
+  // 0613 is the latest model with better model steerability, enable by default.
+  GPT_3_5 = 'gpt-3.5-turbo-0613',
   GPT_3_5_AZ = 'gpt-35-turbo',
+  GPT_3_5_16K = 'gpt-3.5-turbo-16k',
   GPT_4 = 'gpt-4',
   GPT_4_32K = 'gpt-4-32k',
 }
@@ -28,6 +30,12 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     name: 'GPT-3.5',
     maxLength: 12000,
     tokenLimit: 4000,
+  },
+  [OpenAIModelID.GPT_3_5_16K]: {
+    id: OpenAIModelID.GPT_3_5_16K,
+    name: 'GPT-3.5-16K',
+    maxLength: 48000,
+    tokenLimit: 16000,
   },
   [OpenAIModelID.GPT_4]: {
     id: OpenAIModelID.GPT_4,

--- a/utils/app/api.ts
+++ b/utils/app/api.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_SYSTEM_PROMPT, DEFAULT_TEMPERATURE } from '@/utils/app/const';
 
 import { Conversation } from '@/types/chat';
-import { OpenAIModels } from '@/types/openai';
+import { OpenAIModelID, OpenAIModels } from '@/types/openai';
 import { Plugin, PluginID } from '@/types/plugin';
 import dayjs from 'dayjs';
 
@@ -47,7 +47,7 @@ export async function fetchShareableConversation(
       id: accessibleId,
       name: title + ' (Shared)',
       messages: JSON.parse(prompts),
-      model: OpenAIModels['gpt-3.5-turbo'],
+      model: OpenAIModels['gpt-3.5-turbo-0613'],
       prompt: DEFAULT_SYSTEM_PROMPT,
       folderId: null,
       temperature: DEFAULT_TEMPERATURE,

--- a/utils/server/api.ts
+++ b/utils/server/api.ts
@@ -60,3 +60,22 @@ export const shortenMessagesBaseOnTokenLimit = async (
     return messagesToSend;
   }
 };
+
+export const getMessagesTokenCount = async (messages: Message[]): Promise<number> => {
+  await init((imports) => WebAssembly.instantiate(wasm, imports));
+
+  const encoding = new Tiktoken(
+    tiktokenModel.bpe_ranks,
+    tiktokenModel.special_tokens,
+    tiktokenModel.pat_str,
+  );
+
+  let tokenCount = 0;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const tokens = encoding.encode(message.content);
+    tokenCount += tokens.length;
+  }
+
+  return tokenCount;
+};


### PR DESCRIPTION
Add support for 16k context window, since the gpt-3.5 model default only has 4k tokens in context window. OpenAI rolled out a new gpt-3.5-16k model, and this is the PR to integrate that into the app. 

If the messages (both conversation history or a single message) is below 4k tokens, we will still use gpt-3.5 by default to save cost. 

Demo Clip:

https://github.com/exploratortech/chat-everywhere/assets/4432048/5f83c3fa-d513-4ec4-a57e-cabbb17cd3b8

