### PR TITLE
Switch to Azure api for free and non-login users

### DIFF
--- a/pages/api/chat-gpt4.ts
+++ b/pages/api/chat-gpt4.ts
@@ -29,7 +29,7 @@ const handler = async (req: Request): Promise<Response> => {
   if (!data || error) return unauthorizedResponse;
 
   const user = await getUserProfile(data.user.id);
-  if (!user || user.plan !== 'pro') return unauthorizedResponse;
+  if (!user || user.plan === 'free') return unauthorizedResponse;
 
   if (await hasUserRunOutOfCredits(data.user.id, PluginID.GPT4)) {
     return new Response('Error', {

--- a/pages/api/chat-gpt4.ts
+++ b/pages/api/chat-gpt4.ts
@@ -29,7 +29,7 @@ const handler = async (req: Request): Promise<Response> => {
   if (!data || error) return unauthorizedResponse;
 
   const user = await getUserProfile(data.user.id);
-  if (!user || user.plan === 'free') return unauthorizedResponse;
+  if (!user || user.plan !== 'pro') return unauthorizedResponse;
 
   if (await hasUserRunOutOfCredits(data.user.id, PluginID.GPT4)) {
     return new Response('Error', {

--- a/pages/api/chat-gpt4.ts
+++ b/pages/api/chat-gpt4.ts
@@ -81,6 +81,8 @@ const handler = async (req: Request): Promise<Response> => {
       promptToSend,
       temperatureToUse,
       messagesToSend,
+      null,
+      true,
     );
 
     return new Response(stream);

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -41,9 +41,9 @@ const handler = async (req: Request): Promise<Response> => {
     const requireToUseLargerContextWindowModel =
       (await getMessagesTokenCount(messages)) + 1000 > defaultTokenLimit; // Add buffer token to take system prompt into account
 
+    const isPaidUser = await isPaidUserByAuthToken(req.headers.get('user-token'));
     const useLargerContextWindowModel =
-      requireToUseLargerContextWindowModel &&
-      (await isPaidUserByAuthToken(req.headers.get('user-token')));
+      requireToUseLargerContextWindowModel && isPaidUser;
 
     const messagesToSend = await shortenMessagesBaseOnTokenLimit(
       prompt,
@@ -75,7 +75,8 @@ const handler = async (req: Request): Promise<Response> => {
       promptToSend,
       temperatureToUse,
       messagesToSend,
-      messageToStreamBack
+      messageToStreamBack,
+      isPaidUser,
     );
 
     return new Response(stream);

--- a/utils/app/const.ts
+++ b/utils/app/const.ts
@@ -20,3 +20,15 @@ export const DEFAULT_IMAGE_GENERATION_STYLE = "Default";
 export const DEFAULT_IMAGE_GENERATION_QUALITY = "high";
 
 export const RANK_INTERVAL = 100;
+
+export const AZURE_OPENAI_ENDPOINTS = [
+  process.env.AZURE_OPENAI_ENDPOINT_1,
+  process.env.AZURE_OPENAI_ENDPOINT_2,
+  process.env.AZURE_OPENAI_ENDPOINT_3,
+];
+
+export const AZURE_OPENAI_KEYS = [
+  process.env.AZURE_OPENAI_KEY_1,
+  process.env.AZURE_OPENAI_KEY_2,
+  process.env.AZURE_OPENAI_KEY_3,
+];

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -169,7 +169,6 @@ export const OpenAIStream = async (
               } else {
                 controller.close();
               }
-              console.log('controller closed');
               clearInterval(interval);
             }
           }, 45);

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -43,7 +43,7 @@ export const OpenAIStream = async (
   customMessageToStreamBack?: string | null, // Stream this string at the end of the streaming
 ) => {
   // let url = `${OPENAI_API_HOST}/v1/chat/completions`;
-  let url = `${process.env.AZURE_OPENAI_ENDPOINT}/openai/deployments/gpt35-16k/chat/completions?api-version=2023-06-01-preview`;
+  let url = `${process.env.AZURE_OPENAI_ENDPOINT}/openai/deployments/gpt-35/chat/completions?api-version=2023-05-15`;
 
   // Ensure you have the OPENAI_API_GPT_4_KEY set in order to use the GPT-4 model
   const apiKey =
@@ -141,13 +141,14 @@ export const OpenAIStream = async (
           const data = buffer.shift();
           controller.enqueue(data);
         }
+
         if (stop) {
           if (buffer.length === 0) {
             controller.close();
             clearInterval(interval);
           }
         }
-      }, 25);
+      }, 45);
     },
   });
 

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -83,7 +83,9 @@ export const OpenAIStream = async (
       };
 
       if (openAIEndpoint.includes('openai.com')) {
-        bodyToSend.model = model.id;
+        // Use the model the user specified on the first attempt, otherwise, use
+        // a fallback model.
+        bodyToSend.model = attempt === 0 ? model.id : OpenAIModelID.GPT_3_5;
         requestHeaders.Authorization = `Bearer ${openAIKey}`;
       } else {
         requestHeaders['api-key'] = openAIKey;


### PR DESCRIPTION
We want to use the Azure API for non-login or free users, and preserve the OpenAI calls to Pro user only. 

**Things to note:**
- We have 3 difference endpoints from Azure for load balancing, each of them has _1440 (Request per minute)/ 240k (Tokens per Minute) Rate_ capacity. so we need a simple load balancer to handle that (randomly pick one from 3 is good enough)
- We should also implement a fallback to OpenAI in case Azure is down. But the fallback order should be `Azure 1 -> Azure 2 -> Azure 3 -> OpenAI`
- We only have Azure for gpt-3.5 model, and we will use gpt-4 exclusively from OpenAI