### PR TITLE
A workaround for iOS PWA: the keyboard remains invisible while active.

### DIFF
--- a/hooks/useFocusInputHandler.ts
+++ b/hooks/useFocusInputHandler.ts
@@ -1,6 +1,4 @@
-import { useState, useEffect, useRef, RefObject, useContext } from 'react';
-
-import HomeContext from '@/pages/api/home/home.context';
+import { RefObject, useEffect, useRef, useState } from 'react';
 
 interface FocusHandlerResult {
   isFocused: boolean;
@@ -8,12 +6,19 @@ interface FocusHandlerResult {
   menuRef: RefObject<HTMLDivElement>;
 }
 
-function useFocusHandler(textareaRef: RefObject<HTMLTextAreaElement>): FocusHandlerResult {
+function useFocusHandler(
+  textareaRef: RefObject<HTMLTextAreaElement>,
+): FocusHandlerResult {
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const handleFocus = (e: MouseEvent) => {
+      // Please do not remove this code. It serves as a workaround for a bug in iOS PWA standalone mode. Occasionally, the textarea receives focus, but the keyboard does not appear.
+      if (document.documentElement.scrollTop > 1) {
+        document.documentElement.scrollTop = document.documentElement.scrollTop;
+      }
+
       if (
         menuRef.current &&
         menuRef.current.contains(e.target as HTMLDivElement)
@@ -34,7 +39,7 @@ function useFocusHandler(textareaRef: RefObject<HTMLTextAreaElement>): FocusHand
     };
   }, [textareaRef]);
 
-  return { isFocused, menuRef , setIsFocused};
+  return { isFocused, menuRef, setIsFocused };
 }
 
 export default useFocusHandler;


### PR DESCRIPTION
Bug Triggering condition:
- on iOS PWA
- Click the enhanced menu button while currently focusing on the textarea.

What happened?
- The keyboard is still opened but invisible

Reference:
- Its a known issue on iOS. https://discussions.apple.com/thread/253685039


https://github.com/exploratortech/chat-everywhere/assets/53516684/fb3e7096-8573-4cfd-9173-2d0bc8b40174


