### PR TITLE
Fix unable to share to LINE

### DIFF
--- a/components/Chat/LineShareButton.tsx
+++ b/components/Chat/LineShareButton.tsx
@@ -27,7 +27,7 @@ export const LineShareButton: FC<LineShareButtonProps> = ({
 }) => {
   const { t } = useTranslation('feature');
   const {
-    state: { user },
+    state: { user, isConnectedWithLine },
   } = useContext(HomeContext);
   const [loading, setLoading] = useState(false);
   const supabase = useSupabaseClient();
@@ -47,7 +47,7 @@ export const LineShareButton: FC<LineShareButtonProps> = ({
       return;
     }
 
-    if (!user.isConnectedWithLine) {
+    if (!isConnectedWithLine) {
       toast.error(t('Please connect with your Line account first.'));
       homeDispatch({ field: 'showSettingsModel', value: true });
       return;


### PR DESCRIPTION
This pull request fixes an issue where users were unable to share content to LINE. The problem was caused by a check that was incorrectly referencing the `user` object instead of the `isConnectedWithLine` property. This caused an error message to be displayed even when the user was connected to their LINE account. This PR updates the check to use the correct property and resolves the issue.