### PR TITLE
Improve MJ image Error Handling

### DIFF
--- a/components/Chat/ChatMessage/AssistantRespondMessage.tsx
+++ b/components/Chat/ChatMessage/AssistantRespondMessage.tsx
@@ -7,6 +7,7 @@ import AiPainter from '../components/AiPainter';
 import AiPainterResult from '../components/AiPainterResult';
 import { ImageGenerationComponent } from '../components/ImageGenerationComponent';
 import MjImageComponentV2 from '../components/MjImageComponentV2';
+import MjImageProgress from '../components/MjImageProgress';
 import { CodeBlock } from '@/components/Markdown/CodeBlock';
 import { MemoizedReactMarkdown } from '@/components/Markdown/MemoizedReactMarkdown';
 
@@ -138,6 +139,22 @@ const AssistantRespondMessage = memo(
         rehypePlugins={[rehypeRaw]}
         components={{
           div: ({ node, children, ...props }) => {
+            if (
+              node?.properties?.id === 'MjImageProgress' &&
+              node?.properties?.dataComponentState
+            ) {
+              const componentState = JSON.parse(
+                (node?.properties?.dataComponentState as string) || '{}',
+              ) as any;
+              return (
+                <MjImageProgress
+                  content={componentState.content}
+                  state={componentState.state}
+                  percentage={componentState.percentage}
+                  errorMessage={componentState?.errorMessage || undefined}
+                />
+              );
+            }
             if (node?.properties?.id === 'ai-painter-generated-image') {
               const imageTags = node?.children;
               if (!imageTags) return <>{children}</>;

--- a/components/Chat/components/GeneralHtmlComponentParser.tsx
+++ b/components/Chat/components/GeneralHtmlComponentParser.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+// NOTE: THE COMPONENT IS USED FOR STATIC HTML GENERATION, SO DON'T USE HOOKS OR STATE
+
+const GeneralHtmlComponentParser = ({
+  id,
+  componentState,
+}: {
+  id: string;
+  componentState: object;
+}) => {
+  return (
+    <div id={id} data-component-state={JSON.stringify(componentState)}></div>
+  );
+};
+
+export default GeneralHtmlComponentParser;

--- a/components/Chat/components/MjImageProgress.tsx
+++ b/components/Chat/components/MjImageProgress.tsx
@@ -1,20 +1,23 @@
 import ProgressBar from '@ramonak/react-progress-bar';
 import { IconArrowUp, IconCheck, IconX } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
 
 import Spinner from '@/components/Spinner/Spinner';
-
-// THE COMPONENT IS USED FOR STATIC HTML GENERATION, SO DON'T USE HOOKS OR STATE
 
 export interface MjImageProgressProps {
   content: string;
   state: 'loading' | 'completed' | 'error';
   percentage?: `${number}`;
+  errorMessage?: string;
 }
 export default function MjImageProgress({
   content,
   state,
   percentage,
+  errorMessage,
 }: MjImageProgressProps) {
+  const { t } = useTranslation('common');
+  const { t: chatT } = useTranslation('chat');
   return (
     <details
       className={`${state === 'loading' ? 'bg-white disabled' : ''} ${
@@ -52,7 +55,14 @@ export default function MjImageProgress({
         )}
       </summary>
       <main>
-        <div className="panel p-2 max-h-full">{content}</div>
+        <div className="panel p-2 max-h-full whitespace-pre-line">
+          {content}
+        </div>
+        {errorMessage && (
+          <div className="panel p-2 max-h-full whitespace-pre-line">
+            {`${t('Error')}: ${chatT(errorMessage)} `}
+          </div>
+        )}
       </main>
     </details>
   );

--- a/components/Chat/components/MjImageProgress.tsx
+++ b/components/Chat/components/MjImageProgress.tsx
@@ -1,10 +1,5 @@
 import ProgressBar from '@ramonak/react-progress-bar';
-import {
-  IconArrowDown,
-  IconArrowUp,
-  IconCheck,
-  IconX,
-} from '@tabler/icons-react';
+import { IconArrowUp, IconCheck, IconX } from '@tabler/icons-react';
 
 import Spinner from '@/components/Spinner/Spinner';
 
@@ -27,7 +22,7 @@ export default function MjImageProgress({
       } ${
         state === 'error' ? 'bg-red-200' : ''
       } relative my-4 block text-black rounded-lg`}
-      open={state === 'loading'}
+      open={state === 'loading' || state === 'error'}
     >
       <summary className="cursor-pointer p-2 flex gap-2 items-center justify-between">
         <div className="flex gap-2 items-center flex-grow font-bold">

--- a/pages/api/image-gen.ts
+++ b/pages/api/image-gen.ts
@@ -12,7 +12,7 @@ import {
 } from '@/utils/app/eventTracking';
 import { MJ_INVALID_USER_ACTION_LIST } from '@/utils/app/mj_const';
 import {
-  ProgressHandler,
+  MjProgressProgressHandler,
   makeCreateImageSelectorV2,
   makeWriteToStream,
 } from '@/utils/app/streamHandler';
@@ -130,7 +130,7 @@ const handler = async (req: Request): Promise<Response> => {
 
   const writeToStream = makeWriteToStream(writer, encoder);
   const createImageSelector = makeCreateImageSelectorV2(writeToStream);
-  const progressHandler = new ProgressHandler(writeToStream);
+  const progressHandler = new MjProgressProgressHandler(writeToStream);
 
   const requestBody = (await req.json()) as ChatBody;
 
@@ -332,7 +332,8 @@ const handler = async (req: Request): Promise<Response> => {
               MJ_INVALID_USER_ACTION_LIST.includes(mjResponseContent);
             if (isInvalidUserAction) {
               progressHandler.updateProgress({
-                content: `Error: ${mjResponseContent} \n`,
+                content: mjResponseContent,
+                errorMessage: 'Invalid user action',
                 state: 'error',
               });
 
@@ -409,14 +410,19 @@ const handler = async (req: Request): Promise<Response> => {
         'message' in error.cause
       ) {
         const customErrorMessage = error.cause.message;
+        console.log({
+          customErrorMessage,
+        });
         await progressHandler.updateProgress({
-          content: `Error: ${customErrorMessage} \n`,
+          content: ``,
+          errorMessage: `${customErrorMessage}`,
           state: 'error',
         });
       } else {
         await progressHandler.updateProgress({
-          content:
-            'Error occurred while generating image, please try again later.',
+          content: ``,
+          errorMessage:
+            'Error occurred while generating image, please try again later',
           state: 'error',
         });
       }

--- a/pages/api/image-gen.ts
+++ b/pages/api/image-gen.ts
@@ -209,14 +209,6 @@ const handler = async (req: Request): Promise<Response> => {
       const imageGenerationResponseText = await imageGenerationResponse.text();
 
       if (!imageGenerationResponse.ok) {
-        console.log({
-          imageGenerationResponseText,
-          ContentFilterErrorMessageListFromMyMidjourneyProvider,
-          isInclude: ContentFilterErrorMessageListFromMyMidjourneyProvider.some(
-            (errorMessage) =>
-              imageGenerationResponseText.includes(errorMessage),
-          ),
-        });
         if (
           ContentFilterErrorMessageListFromMyMidjourneyProvider.some(
             (errorMessage) =>

--- a/pages/api/image-to-prompt.ts
+++ b/pages/api/image-to-prompt.ts
@@ -2,7 +2,10 @@ import { NextResponse } from 'next/server';
 
 import { IMAGE_TO_PROMPT_MAX_TIMEOUT } from '@/utils/app/const';
 import { serverSideTrackEvent } from '@/utils/app/eventTracking';
-import { ProgressHandler, makeWriteToStream } from '@/utils/app/streamHandler';
+import {
+  MjProgressProgressHandler,
+  makeWriteToStream,
+} from '@/utils/app/streamHandler';
 import { getAdminSupabaseClient } from '@/utils/server/supabase';
 
 const supabase = getAdminSupabaseClient();
@@ -31,7 +34,7 @@ const handler = async (req: Request): Promise<Response> => {
   const startTime = Date.now();
 
   const writeToStream = makeWriteToStream(writer, encoder);
-  const progressHandler = new ProgressHandler(writeToStream);
+  const progressHandler = new MjProgressProgressHandler(writeToStream);
 
   let jobTerminated = false;
 
@@ -109,7 +112,7 @@ const handler = async (req: Request): Promise<Response> => {
         } else if (textGenerationProgress === null) {
           progressHandler.updateProgress({
             content: `Start to generate \n`,
-            removeLastLine: true
+            removeLastLine: true,
           });
           textGenerationProgress = generationProgress || 0;
         } else {

--- a/pages/api/mj-image-command.ts
+++ b/pages/api/mj-image-command.ts
@@ -4,7 +4,7 @@ import { IMAGE_GEN_MAX_TIMEOUT } from '@/utils/app/const';
 import { serverSideTrackEvent } from '@/utils/app/eventTracking';
 import { MJ_INVALID_USER_ACTION_LIST } from '@/utils/app/mj_const';
 import {
-  ProgressHandler,
+  MjProgressProgressHandler,
   makeCreateImageSelectorV2,
   makeWriteToStream,
 } from '@/utils/app/streamHandler';
@@ -70,7 +70,7 @@ const handler = async (req: Request): Promise<Response> => {
     Math.round((Date.now() - generationStartedAt) / 1000);
 
   const createImageSelector = makeCreateImageSelectorV2(writeToStream);
-  const progressHandler = new ProgressHandler(writeToStream);
+  const progressHandler = new MjProgressProgressHandler(writeToStream);
 
   progressHandler.updateProgress({ content: `Command: ${button} ... \n` });
   progressHandler.updateProgress({
@@ -197,7 +197,7 @@ const handler = async (req: Request): Promise<Response> => {
         if (imageGenerationProgress === null) {
           progressHandler.updateProgress({
             content: `Start to generate \n`,
-            removeLastLine: true
+            removeLastLine: true,
           });
         } else {
           progressHandler.updateProgress({

--- a/public/locales/zh-Hans/chat.json
+++ b/public/locales/zh-Hans/chat.json
@@ -23,7 +23,7 @@
   "click if using a .env.local file": "click if using a .env.local file",
   "Message limit is {{maxLength}} characters. You have entered {{valueLength}} characters.": "消息字数限制为 {{maxLength}} 个字符。您已输入 {{valueLength}} 个字符。",
   "Please enter a message": "请输入一条消息",
-  "Where the forefront of AI technology meets universal access.": "把AI帶到每個人的生活中",
+  "Where the forefront of AI technology meets universal access.": "把AI带到每个人的生活中",
   "Are you sure you want to clear all messages?": "你确定要清除所有的消息吗？",
   "Switch to Sample Prompts": "切换到范例",
   "Switch to Role Play": "切换到角色扮演",
@@ -65,5 +65,7 @@
   "This file does not exist, it will be deleted from the chat": "此档案不存在，将从对话中删除",
   "Join our event in {{hours}} hours!": "不要错过我们这次精彩的官方活动哦！倒计时 {{hours}} 小时！",
   "Join our event in {{minutes}} minutes!": "不要错过我们这次精彩的官方活动哦！倒计时 {{minutes}} 分钟！",
-  "Event is now live!": "活动正式开始，快加入我们吧！"
+  "Event is now live!": "活动正式开始，快加入我们吧！",
+  "Error occurred while generating image, please try again later": "生成图像时出错，请稍后再试",
+  "Failed to enhance the prompt after multiple attempts": "多次尝试后仍无法优化提示词"
 }

--- a/public/locales/zh-Hans/common.json
+++ b/public/locales/zh-Hans/common.json
@@ -10,5 +10,6 @@
   "Thank you for your understanding and patience.": "感谢您的理解和耐心。",
   "Upload": "上传",
   "File uploaded successfully": "文件上传成功",
-  "File upload failed": "文件上传失败"
+  "File upload failed": "文件上传失败",
+  "Error": "错误"
 }

--- a/public/locales/zh-Hant/chat.json
+++ b/public/locales/zh-Hant/chat.json
@@ -65,5 +65,7 @@
   "This file does not exist, it will be deleted from the chat": "此檔案不存在，將從對話中刪除",
   "Join our event in {{hours}} hours!": "不要錯過我們這次精彩的官方活動喔! 倒計時 {{hours}} 小時!",
   "Join our event in {{minutes}} minutes!": "不要錯過我們這次精彩的官方活動喔! 倒計時 {{minutes}} 分鐘!",
-  "Event is now live!": "活動正式開始, 快加入我們吧!"
+  "Event is now live!": "活動正式開始, 快加入我們吧!",
+  "Error occurred while generating image, please try again later": "生成圖像時出錯，請稍後再試",
+  "Failed to enhance the prompt after multiple attempts": "多次嘗試後仍無法優化提示詞"
 }

--- a/public/locales/zh-Hant/common.json
+++ b/public/locales/zh-Hant/common.json
@@ -10,5 +10,6 @@
   "Thank you for your understanding and patience.": "感謝您的理解與耐心。",
   "Upload": "上傳",
   "File uploaded successfully": "檔案上傳成功",
-  "File upload failed": "檔案上傳失敗"
+  "File upload failed": "檔案上傳失敗",
+  "Error": "錯誤"
 }

--- a/utils/app/streamHandler.ts
+++ b/utils/app/streamHandler.ts
@@ -1,5 +1,6 @@
 import { removeLastLine as removeLastLineF } from './../../utils/app/ui';
 
+import GeneralHtmlComponentParser from '@/components/Chat/components/GeneralHtmlComponentParser';
 import MjImageProgress from '@/components/Chat/components/MjImageProgress';
 import MjImageSelector, {
   MjImageSelectorProps,
@@ -65,7 +66,7 @@ export const makeCreateImageSelector = (writeToStream: WriteToStream) => {
   };
 };
 
-export class ProgressHandler {
+export class MjProgressProgressHandler {
   private progressContent = '';
 
   constructor(private writeToStream: WriteToStream) {}
@@ -75,23 +76,29 @@ export class ProgressHandler {
     state = 'loading',
     removeLastLine = false,
     percentage,
+    errorMessage,
   }: {
     content: string;
     state?: 'loading' | 'completed' | 'error';
     removeLastLine?: boolean;
     percentage?: `${number}`;
     previewImageUrl?: string;
+    errorMessage?: string;
   }) {
     if (removeLastLine) {
       this.progressContent = removeLastLineF(this.progressContent);
     }
     this.progressContent += content;
     const html = await generateComponentHTML({
-      component: MjImageProgress,
+      component: GeneralHtmlComponentParser,
       props: {
-        content: this.progressContent,
-        state,
-        percentage,
+        id: 'MjImageProgress',
+        componentState: {
+          content: this.progressContent,
+          state,
+          percentage,
+          errorMessage: errorMessage || undefined,
+        },
       },
       temp: true,
     });

--- a/utils/server/functionCalls/llmHandlerHelpers.ts
+++ b/utils/server/functionCalls/llmHandlerHelpers.ts
@@ -23,7 +23,9 @@ const helperFunctionNames = {
   generateHtmlForAiPainterImages: 'generate-html-for-ai-painter-images',
 };
 
-const isInProductionOrLocalEnv = process.env.NEXT_PUBLIC_ENV === 'production' || process.env.NEXT_PUBLIC_ENV === 'local';
+const isInProductionOrLocalEnv =
+  process.env.NEXT_PUBLIC_ENV === 'production' ||
+  process.env.NEXT_PUBLIC_ENV === 'local';
 
 export const getHelperFunctionCalls = (
   lineAccessToken?: string,
@@ -170,7 +172,6 @@ export const triggerHelperFunction = async (
           const { data: imagePublicUrlData } = await supabase.storage
             .from('ai-images')
             .getPublicUrl(imageFileName);
-  
 
           const compressedImageUrl = supabase.storage
             .from('ai-images')
@@ -215,7 +216,9 @@ export const triggerHelperFunction = async (
           }
           return {
             revised_prompt: imageGenerationResponse.data[0].revised_prompt,
-            imagePublicUrl: isInProductionOrLocalEnv ? compressedUrl : imagePublicUrl,
+            imagePublicUrl: isInProductionOrLocalEnv
+              ? compressedUrl
+              : imagePublicUrl,
             fileName,
           };
         } catch (e) {

--- a/utils/server/imageGen.ts
+++ b/utils/server/imageGen.ts
@@ -146,7 +146,7 @@ export const translateAndEnhancePrompt = async (prompt: string) => {
       return functionParameters.prompt;
     }
   } catch (error) {
-    // Handle and rethrow the error
+    // Throw the error above
     throw error;
   }
 };

--- a/utils/server/imageGen.ts
+++ b/utils/server/imageGen.ts
@@ -2,67 +2,48 @@ import { FunctionCall } from '@/types/chat';
 
 import { OPENAI_API_HOST } from '../app/const';
 
-export const translateAndEnhancePrompt = async (prompt: string) => {
+const functionCallsToSend: FunctionCall[] = [
+  {
+    name: 'error-message',
+    description: 'error message',
+    parameters: {
+      type: 'object',
+      properties: {
+        errorMessage: {
+          type: 'string',
+          description: 'error message',
+        },
+      },
+    },
+  },
+  {
+    name: 'generate-image',
+    description: 'generate an image from a prompt',
+    parameters: {
+      type: 'object',
+      properties: {
+        prompt: {
+          type: 'string',
+          description: 'prompt to generate the image. must be in english.',
+        },
+      },
+    },
+  },
+];
+
+async function callOpenAIAPI(
+  prompt: string,
+  functionCallsToSend: FunctionCall[],
+) {
   const url = `${OPENAI_API_HOST}/v1/chat/completions`;
-
-  const translateSystemPrompt = `
-    Act as an AI image generation expert and a professional translator, follow user's instruction as strictly as possible.
-    First determine the prompt's language:
-      If the prompt is not in English:
-        1. Translate the prompt to English, keeping in mind the context for simplicity
-        2. Embellish the translated prompt with additional details for enhanced visual appeal
-        3. Make sure your response is solely in English
-
-      if the prompt is in english:
-        1. Simply echo the original prompt verbatim
-        2. Refrain from making any alterations to the original prompt
-
-    Afterward, called the available function based on the following condition:
-      if the prompt is ready to be processed:
-        - call the 'generate-image' function with the prompt.
-      if there are anything wrong or the prompt is not ready for processing:
-        - call the 'error-message' function indicating the errorMessage
-
-    Important to note: you must only called the function with the name 'generate-image' or 'error-message', there is no need to response without calling the function.
-    `;
-  const functionCallsToSend: FunctionCall[] = [
-    {
-      name: 'error-message',
-      description: 'error message',
-      parameters: {
-        type: 'object',
-        properties: {
-          errorMessage: {
-            type: 'string',
-            description: 'error message',
-          },
-        },
-      },
-    },
-    {
-      name: 'generate-image',
-      description: 'generate an image from a prompt',
-      parameters: {
-        type: 'object',
-        properties: {
-          prompt: {
-            type: 'string',
-            description: 'prompt to generate the image. must be in english.',
-          },
-        },
-      },
-    },
-  ];
-
-  const completionResponse = await fetch(url, {
+  const response = await fetch(url, {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${process.env.OPENAI_API_GPT_4_KEY}`,
     },
     method: 'POST',
     body: JSON.stringify({
-      // model: 'gpt-4o',
-      model: 'gpt-3.5-turbo',
+      model: 'gpt-4o',
       temperature: 0.1,
       stream: false,
       functions: functionCallsToSend,
@@ -79,85 +60,93 @@ export const translateAndEnhancePrompt = async (prompt: string) => {
     }),
   });
 
-  const completionResponseJson = await completionResponse.json();
+  const responseJson = await response.json();
+  console.log('responseJson', JSON.stringify(responseJson));
 
-  console.log('completionResponseJson', JSON.stringify(completionResponseJson));
-
-  if (
-    completionResponseJson.error &&
-    completionResponseJson.error.code === 'content_filter'
-  ) {
-    throw new Error('Translate and enhance prompt error', {
-      cause: {
-        code: completionResponseJson.error.code,
-        message:
-          'Sorry, our safety system detected unsafe content in your message. Please try again with a different topic.',
-      },
-    });
-  }
-  console.log({
-    message: completionResponseJson.choices[0].message,
-  });
-  if (completionResponse.status !== 200) {
-    console.log('Image generation failed', completionResponseJson);
+  if (response.status !== 200) {
+    console.log('Image generation failed', responseJson);
     throw new Error('Image generation failed');
   }
 
-  let functionCallResponse =
-    completionResponseJson.choices[0].message.function_call;
+  return responseJson;
+}
 
-  const maxRetries = 3;
-  let currentRetry = 0;
+const translateSystemPrompt = `
+  Act as an AI image generation expert and a professional translator, follow user's instruction as strictly as possible.
+  First determine the prompt's language:
+    If the prompt is not in English:
+      1. Translate the prompt to English, keeping in mind the context for simplicity
+      2. Embellish the translated prompt with additional details for enhanced visual appeal
+      3. Make sure your response is solely in English
 
-  while (!functionCallResponse && currentRetry < maxRetries) {
-    console.log(`Retry ${currentRetry + 1}/${maxRetries}`);
-    const retryResponse = await fetch(url, {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_GPT_4_KEY}`,
-      },
-      method: 'POST',
-      body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        temperature: 0.1,
-        stream: false,
-        functions: functionCallsToSend,
-        messages: [
-          {
-            role: 'system',
-            content: translateSystemPrompt,
-          },
-          {
-            role: 'user',
-            content: `Prompt: ${prompt}`,
-          },
-        ],
-      }),
-    });
-    const retryResponseJson = await retryResponse.json();
-    functionCallResponse = retryResponseJson.choices[0].message.function_call;
-    currentRetry++;
-  }
+    if the prompt is in english:
+      1. Simply echo the original prompt verbatim
+      2. Refrain from making any alterations to the original prompt
 
-  if (!functionCallResponse) {
-    throw new Error('Translate and enhance prompt error', {
-      cause: {
-        message: 'Failed to enhance the prompt after multiple attempts',
-      },
-    });
-  }
+  Afterward, called the available function based on the following condition:
+    if the prompt is ready to be processed:
+      - call the 'generate-image' function with the prompt.
+    if there are anything wrong or the prompt is not ready for processing:
+      - call the 'error-message' function indicating the errorMessage
 
-  const functionName = functionCallResponse.name;
-  const functionParameters = JSON.parse(functionCallResponse.arguments);
+  Important to note: you must only called the function with the name 'generate-image' or 'error-message', there is no need to response without calling the function.
+`;
 
-  if (functionName === 'error-message') {
-    throw new Error('Translate and enhance prompt error', {
-      cause: {
-        translateAndEnhancePromptErrorMessage: functionParameters.errorMessage,
-      },
-    });
-  } else if (functionName === 'generate-image') {
-    console.log('resultPrompt', functionParameters.prompt);
-    return functionParameters.prompt;
+export const translateAndEnhancePrompt = async (prompt: string) => {
+  try {
+    const responseJson = await callOpenAIAPI(prompt, functionCallsToSend);
+
+    if (responseJson.error && responseJson.error.code === 'content_filter') {
+      throw new Error('Translate and enhance prompt error', {
+        cause: {
+          code: responseJson.error.code,
+          message:
+            'Sorry, our safety system detected unsafe content in your message. Please try again with a different topic.',
+        },
+      });
+    }
+
+    let functionCallResponse;
+    const maxRetries = 3;
+
+    for (let i = 0; i < maxRetries; i++) {
+      const retryResponseJson = await callOpenAIAPI(
+        prompt,
+        functionCallsToSend,
+      );
+      functionCallResponse = retryResponseJson.choices[0].message.function_call;
+
+      if (functionCallResponse) {
+        break;
+      }
+
+      console.log(`Retry ${i + 1}/${maxRetries}`);
+    }
+
+    if (!functionCallResponse) {
+      throw new Error('Translate and enhance prompt error', {
+        cause: {
+          message: 'Failed to enhance the prompt after multiple attempts',
+        },
+      });
+    }
+
+    const functionName = functionCallResponse.name;
+    const functionParameters = JSON.parse(functionCallResponse.arguments);
+
+    if (functionName === 'error-message') {
+      throw new Error('Translate and enhance prompt error', {
+        cause: {
+          translateAndEnhancePromptErrorMessage:
+            functionParameters.errorMessage,
+        },
+      });
+    } else if (functionName === 'generate-image') {
+      console.log('resultPrompt', functionParameters.prompt);
+      return functionParameters.prompt;
+    }
+  } catch (error) {
+    // Handle and rethrow the error
+    throw error;
   }
 };

--- a/utils/server/imageGen.ts
+++ b/utils/server/imageGen.ts
@@ -81,14 +81,16 @@ export const translateAndEnhancePrompt = async (prompt: string) => {
   const completionResponseJson = await completionResponse.json();
 
   console.log('completionResponseJson', JSON.stringify(completionResponseJson));
+
   if (
     completionResponseJson.error &&
     completionResponseJson.error.code === 'content_filter'
   ) {
     throw new Error('Translate and enhance prompt error', {
       cause: {
-        translateAndEnhancePromptErrorMessage:
-          'Your input appears to contain elements that could be related to sexual content, hate speech, self-harm, or violence. These topics are against our guidelines. We kindly ask you to revise your content and try again. We appreciate your understanding and cooperation in maintaining a safe and respectful environment',
+        code: completionResponseJson.error.code,
+        message:
+          'Sorry, our safety system detected unsafe content in your message. Please try again with a different topic.',
       },
     });
   }
@@ -124,3 +126,5 @@ export const translateAndEnhancePrompt = async (prompt: string) => {
     throw new Error('Translate and enhance prompt error');
   }
 };
+
+// TODO: Handle not calling any function


### PR DESCRIPTION
- when GPT not call `image-gen` function, retry 3 times at least
- Give a custom error message when inappropriate wording is detected in the content filter.
- Make `MjProgress` Component render in client-side to handle i18n translation for error message 
- Make the MjProgress toggle opened for error state so that the error message always visible