### PR TITLE
Derek/20240716 fix share to teacher message failed due to payload too large

### DIFF
--- a/components/Chat/StudentShareMessageButton.tsx
+++ b/components/Chat/StudentShareMessageButton.tsx
@@ -1,15 +1,13 @@
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { IconBallpen, IconLoader } from '@tabler/icons-react';
 import type { FC } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from 'react-tooltip';
 
 import { trackEvent } from '@/utils/app/eventTracking';
 import { truncateText } from '@/utils/data/truncateText';
-
-import { encode } from 'base64-arraybuffer';
 
 interface StudentShareMessageBtnProps {
   className?: string;
@@ -31,20 +29,13 @@ const StudentShareMessageButton: FC<StudentShareMessageBtnProps> = ({
   const [loading, setLoading] = useState(false);
   const supabase = useSupabaseClient();
 
-  let imageFileInBase64: String | null = null;
-
   const shareOnClick = async () => {
     setLoading(true);
-    if (imageFileUrl) {
-      const response = await fetch(imageFileUrl);
-      const blob = await response.arrayBuffer();
-      imageFileInBase64 = encode(blob);
-    }
     const payload = {
       accessToken: (await supabase.auth.getSession()).data.session
         ?.access_token,
       messageContent: messageContent,
-      imageFile: imageFileInBase64,
+      imageFileUrl,
     };
     try {
       const response = await fetch('/api/create-message-submission', {

--- a/pages/api/create-message-submission.ts
+++ b/pages/api/create-message-submission.ts
@@ -1,6 +1,7 @@
 import { getAdminSupabaseClient } from '@/utils/server/supabase';
-import { z } from 'zod';
+
 import { v4 } from 'uuid';
+import { z } from 'zod';
 
 export const config = {
   runtime: 'edge',
@@ -29,11 +30,6 @@ const handler = async (req: Request) => {
 
   const supabase = getAdminSupabaseClient();
 
-  if (!accessToken || (messageContent === '' && !imageFileUrl)) {
-    return new Response('Missing accessToken or messageContent or imageFileUrl', {
-      status: 400,
-    });
-  }
   const userRes = await supabase.auth.getUser(accessToken);
 
   if (!userRes || userRes.error) {
@@ -71,7 +67,8 @@ const handler = async (req: Request) => {
   const temporaryAccountId = profileData[0].temp_account_id;
   const teacherProfileId = profileData[0].teacher_profile_id;
   const student_name = profileData[0].uniqueid;
-  const tagIds = profileData[0].tag_ids.filter((id: string) => id !== null) || [];  
+  const tagIds =
+    profileData[0].tag_ids.filter((id: string) => id !== null) || [];
 
   let imagePublicUrl = '';
 

--- a/pages/api/create-message-submission.ts
+++ b/pages/api/create-message-submission.ts
@@ -1,6 +1,5 @@
 import { getAdminSupabaseClient } from '@/utils/server/supabase';
-
-import { decode } from 'base64-arraybuffer';
+import { z } from 'zod';
 import { v4 } from 'uuid';
 
 export const config = {
@@ -8,25 +7,33 @@ export const config = {
   preferredRegion: 'icn1',
 };
 
+const requestBodySchema = z.object({
+  accessToken: z.string(),
+  messageContent: z.string(),
+  imageFileUrl: z.string().nullable(),
+});
+
 const handler = async (req: Request) => {
   if (req.method !== 'POST') {
     return new Response('Method not allowed', { status: 405 });
   }
 
-  const { accessToken, messageContent, imageFile } = (await req.json()) as {
-    accessToken: string;
-    messageContent: string;
-    imageFile: string | null;
-  };
+  let parsedBody;
+  try {
+    parsedBody = requestBodySchema.parse(await req.json());
+  } catch (e) {
+    return new Response('Invalid request body', { status: 400 });
+  }
+
+  const { accessToken, messageContent, imageFileUrl } = parsedBody;
 
   const supabase = getAdminSupabaseClient();
 
-  if (!accessToken || (messageContent === '' && !imageFile)) {
-    return new Response('Missing accessToken or messageContent or imageFile', {
+  if (!accessToken || (messageContent === '' && !imageFileUrl)) {
+    return new Response('Missing accessToken or messageContent or imageFileUrl', {
       status: 400,
     });
   }
-
   const userRes = await supabase.auth.getUser(accessToken);
 
   if (!userRes || userRes.error) {
@@ -64,13 +71,19 @@ const handler = async (req: Request) => {
   const temporaryAccountId = profileData[0].temp_account_id;
   const teacherProfileId = profileData[0].teacher_profile_id;
   const student_name = profileData[0].uniqueid;
-  const tagIds =
-    profileData[0].tag_ids.filter((id: string) => id !== null) || [];
+  const tagIds = profileData[0].tag_ids.filter((id: string) => id !== null) || [];  
 
   let imagePublicUrl = '';
 
-  if (imageFile) {
-    const imageFileBlob = decode(imageFile);
+  if (imageFileUrl) {
+    const response = await fetch(imageFileUrl);
+    if (!response.ok) {
+      console.error('Error downloading image:', response.statusText);
+      return new Response('Error downloading image', {
+        status: 500,
+      });
+    }
+    const imageFileBlob = await response.blob();
     const originalImagePath = `${userId}-${v4()}.png`;
 
     // 1. Upload the image file to Supabase Storage
@@ -88,7 +101,7 @@ const handler = async (req: Request) => {
     }
 
     // 2. Retrieve the public URL of the image file
-    const { data } = await supabase.storage
+    const { data } = supabase.storage
       .from('student_message_submissions_image')
       .getPublicUrl(originalImagePath);
     imagePublicUrl = data.publicUrl || '';

--- a/pages/api/teacher-prompt-for-student.ts
+++ b/pages/api/teacher-prompt-for-student.ts
@@ -13,7 +13,6 @@ export const config = {
 
 const handler = async (req: Request): Promise<Response> => {
   const userProfile = await fetchUserProfileWithAccessToken(req);
-  console.log('123123');
   if (
     !userProfile ||
     (!userProfile.isTempUser && !userProfile.isTeacherAccount)


### PR DESCRIPTION

## Cause

- We send over the image base64 string to the backend, and the base64 string is too large to be sent over the network.


## Solution

1. We can send the image url instead of the base64 string.

## Changes 

- Update the frontend to send the image url instead of the base64 string.
- Update the API to send the image url instead of the base64 string.
- Update the backend to handle the image url instead of the base64 string.
    - Download the image from the url.
    - Convert the image to base64 string.


